### PR TITLE
modified pet-snapshots route to account for changes in data gathering

### DIFF
--- a/lib/routes/pet-snapshots.js
+++ b/lib/routes/pet-snapshots.js
@@ -4,18 +4,21 @@ const petModel = require('../models/pet');
 const petSnapshotModel = require('../models/pet-snapshot');
 
 router
-    .get('/:id', bodyParser, (req, res, next) => {
-        const id = req.params.id;
+    .get('/:animalId/all', bodyParser, (req, res, next) => {
+        //get all data related to a specific pet
+        const animalId = req.params.animalId;
         const datapoints = 50; //arbitrary number of data points
         Promise
             .all([
                 petModel
-                    .findById(id)
+                    .findById(animalId)
                     .lean(),
                 petSnapshotModel
-                    .find({animalId: id})
+                    .find({animalId})
+                    .select('_id date animalId')
                     .sort('date')
-                    .limit(datapoints) 
+                    .limit(datapoints)
+                    .lean() 
             ])
             .then(([pet,data]) => {
                 pet.data = data;
@@ -23,9 +26,20 @@ router
             })
             .catch(next);
     })
-    .post('/:id', bodyParser, (req, res, next) => {
+    .get('/:id', bodyParser, (req, res, next) => {
+        // will get a specific snapshot
+        const id = req.params.id;
+        petSnapshotModel
+            .findById(id)
+            .lean()
+            .then(snapshot => {
+                res.send(snapshot);
+            })
+            .catch(next);
+    })
+    .post('/:animalId', bodyParser, (req, res, next) => {
         // body must contain the pets id
-        req.body.animalId = req.params.id;
+        req.body.animalId = req.params.animalId;
         new petSnapshotModel(req.body).save()
             .then(data => {
                 res.send(data);
@@ -33,10 +47,9 @@ router
             .catch(next);
     })
     .delete('/:id', bodyParser, (req, res, next) => {
-        const animalId = req.params.id;
+        // deletes a specific snapshot
         petSnapshotModel
-            .find({animalId})
-            .remove()
+            .findByIdAndRemove(req.params.id)
             .then(removedData => {
                 res.send(removedData);
             })


### PR DESCRIPTION
Features added:

-Made it so that snapshot route gets all data related to a pet using '/:animalId/all' in routes
-Made it so get '/:id' is the id of the specific snapshot in question
-Made it so delete '/:id' deletes on that specific snapshot
-Made it so post '/:animalId' posts the snapshot to the database for that given animal
-Included update endpoint test for pet-snapshots to account for changes