### PR TITLE
made it so posting snapshot data does not resend the entire snapshot …

### DIFF
--- a/lib/routes/pet-snapshots.js
+++ b/lib/routes/pet-snapshots.js
@@ -51,7 +51,9 @@ router
         req.body.animalId = req.params.animalId;
         new petSnapshotModel(req.body).save()
             .then(data => {
-                res.send(data);
+                let id = data._id;
+                let name = data.name;
+                res.send({id, name});
             })
             .catch(next);
     })

--- a/test/pet-snapshots.api.test.js
+++ b/test/pet-snapshots.api.test.js
@@ -92,7 +92,6 @@ describe('tests pet snapshots endpoint on server', () => {
             .then(res => {
                 assert.isOk(res.body);
                 assert.equal(res.body.name, data.name);
-                assert.deepEqual(res.body.dataPayload, data.dataPayload);
                 done();
             })
             .catch(done);


### PR DESCRIPTION
…back as this would be a waste of network resource, simply send back name of pet and id of snapshot